### PR TITLE
Improve OCaml runtimes compared to C

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <br>
 
-Contributions from received **after** the publication of
+Contributions received **after** the publication of
 ["Nmag micromagnetic simulation tool - software engineering lessons learned"](http://arxiv.org/abs/1601.07392) by Hans Fangohr, Maximilian Albert and Matteo Franchin. In proceedings of the International Workshop on Software Engineering for Science, at ICSE2016 SE4Science '16, 1-7 (2016)
 
 Journal URL: http://dl.acm.org/citation.cfm?doid=2897676.2897677

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Contributions from users after the publication of the paper
+# Contributions from users/readers after the publication of the paper
 
 [![DOI](https://zenodo.org/badge/20165/fangohr/paper-supplement-ocaml-performance.svg)](https://zenodo.org/badge/latestdoi/20165/fangohr/paper-supplement-ocaml-performance) <a href="http://arxiv.org/abs/1601.07392"><img src="https://img.shields.io/badge/preprint-arxiv:1601.07392-lightgrey.svg" alt="arxiv"></a>
 <a href="http://dl.acm.org/citation.cfm?doid=2897676.2897677"><img src="https://img.shields.io/badge/journal-SE4Science-blue.svg" alt="URL"></a>
 
 <br>
 
-Contributions from users received **after** the publication of
+Contributions from received **after** the publication of
 ["Nmag micromagnetic simulation tool - software engineering lessons learned"](http://arxiv.org/abs/1601.07392) by Hans Fangohr, Maximilian Albert and Matteo Franchin. In proceedings of the International Workshop on Software Engineering for Science, at ICSE2016 SE4Science '16, 1-7 (2016)
 
 Journal URL: http://dl.acm.org/citation.cfm?doid=2897676.2897677
@@ -16,8 +16,8 @@ DOI: doi = 10.1145/2897676.2897677
 
 This branch of the repository is a fork of the master branch and contains
 additions and improvements possibly contributed by external parties. While the
-master branch is freezed so that it remains consistent with the original
-publication, this branch is free to evolve and incorporate additional
+master branch is frozen so that it remains consistent with the original
+publication, this branch can evolve and incorporate additional
 observations and suggestions. For example, we could update this branch to
 reflect the state of the latest versions of the OCaml and C/C++ compilers.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
-# Small OCaml performance study
+# Contributions from users after the publication of the paper
 
 [![DOI](https://zenodo.org/badge/20165/fangohr/paper-supplement-ocaml-performance.svg)](https://zenodo.org/badge/latestdoi/20165/fangohr/paper-supplement-ocaml-performance) <a href="http://arxiv.org/abs/1601.07392"><img src="https://img.shields.io/badge/preprint-arxiv:1601.07392-lightgrey.svg" alt="arxiv"></a>
-<a href="http://dl.acm.org/citation.cfm?doid=2897676.2897677"><img src="https://img.shields.io/badge/journal-SE4Science-blue.svg" alt="URL">
+<a href="http://dl.acm.org/citation.cfm?doid=2897676.2897677"><img src="https://img.shields.io/badge/journal-SE4Science-blue.svg" alt="URL"></a>
 
 <br>
 
-Supplement for publication
+Contributions from users received **after** the publication of
 ["Nmag micromagnetic simulation tool - software engineering lessons learned"](http://arxiv.org/abs/1601.07392) by Hans Fangohr, Maximilian Albert and Matteo Franchin. In proceedings of the International Workshop on Software Engineering for Science, at ICSE2016 SE4Science '16, 1-7 (2016)
 
 Journal URL: http://dl.acm.org/citation.cfm?doid=2897676.2897677
 
 DOI: doi = 10.1145/2897676.2897677
 
+## Introduction
+
+This branch of the repository is a fork of the master branch and contains
+additions and improvements possibly contributed by external parties. While the
+master branch is freezed so that it remains consistent with the original
+publication, this branch is free to evolve and incorporate additional
+observations and suggestions. For example, we could update this branch to
+reflect the state of the latest versions of the OCaml and C/C++ compilers.
+
+## Content of this study
 
 This repository contains some test programs that help investigating the
 performance of code emitted by the OCaml compiler (`ocamlopt`) for some of

--- a/array-sum/.gitignore
+++ b/array-sum/.gitignore
@@ -1,0 +1,2 @@
+array_test
+array_test.s

--- a/array-sum/Makefile
+++ b/array-sum/Makefile
@@ -21,3 +21,4 @@ carray_test.s: carray_test.cc
 
 clean:
 	rm -f *.cmi *.cmo *.cmx *.o array_test carray_test
+	rm -f carray_test.s array_test.s

--- a/multidim-arrays/.gitignore
+++ b/multidim-arrays/.gitignore
@@ -1,0 +1,5 @@
+array_of_bigarrays_test
+array_test
+array_test.s
+bigarray_test
+carray_test

--- a/multidim-arrays/Makefile
+++ b/multidim-arrays/Makefile
@@ -3,11 +3,13 @@
 CFLAGS := -std=c++11 -Wall -O3
 RUN_PREFIX := time
 
-all: array_test bigarray_test carray_test
+all: array_test bigarray_test array_of_bigarrays_test carray_test
 	@echo
 	$(RUN_PREFIX) ./array_test
 	@echo
 	$(RUN_PREFIX) ./bigarray_test
+	@echo
+	$(RUN_PREFIX) ./array_of_bigarrays_test
 	@echo
 	$(RUN_PREFIX) ./carray_test
 
@@ -16,7 +18,9 @@ asm: array_test.s carray_test.s
 array_test array_test.s: array_test.ml
 	ocamlfind ocamlopt -package unix -S -linkpkg array_test.ml -o array_test
 bigarray_test: bigarray_test.ml
-	ocamlfind ocamlopt -package unix,bigarray -linkpkg bigarray_test.ml -o bigarray_test
+	ocamlfind ocamlopt -unsafe -package unix,bigarray -linkpkg $^ -o $@
+array_of_bigarrays_test: array_of_bigarrays_test.ml
+	ocamlfind ocamlopt -unsafe -package unix,bigarray -linkpkg $^ -o $@
 
 carray_test: carray_test.cc
 	g++ $(CFLAGS) carray_test.cc -o carray_test
@@ -26,3 +30,5 @@ carray_test.s: carray_test.cc
 
 clean:
 	rm -f *.cmi *.cmo *.cmx *.o array_test bigarray_test carray_test
+	rm -f array_of_bigarrays_test array_test.s
+

--- a/multidim-arrays/array_of_bigarrays_test.ml
+++ b/multidim-arrays/array_of_bigarrays_test.ml
@@ -1,0 +1,81 @@
+(*
+ * Create an array of rank-3 tensors, populate them and compute their norm.
+ * In this example, the tensors are all stored inside a single bigarray.
+ *)
+
+(* Optimize OCaml performance:
+   - Use specialization of bigarrays to 3 dimensions.
+   - Annotate functions with concrete bigarray type so that the compiler knows
+     it need not generate polymorphic code (allows more inlining, etc.).
+   - Compile with -unsafe to disable array bounds checking.
+*)
+
+type tensor_array =
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array3.t array
+
+let pi = 4.0 *. atan 1.0;;
+
+(* Create one array of n 3-rank tensors of size d*d*d. *)
+let create_tensors n d =
+  Array.init n
+    (fun _ -> Bigarray.Array3.create Bigarray.float64 Bigarray.c_layout d d d)
+;;
+
+(* Initialise a tensor. *)
+let init_tensors (tensors : tensor_array) =
+  let n = Array.length tensors in
+  let d = Bigarray.Array3.dim1 tensors.(0) in
+  let fd3 = float_of_int (d*d*d) in
+  let omega = 0.2*.pi in
+  for i = 0 to n - 1; do
+    let x = (float_of_int i)/.(float_of_int n) in
+    for j = 0 to d - 1; do
+      for k = 0 to d - 1; do
+        for l = 0 to d - 1; do
+          (*
+           * dx goes from 0 to 1 while going through the tensor components.
+           * x goes from 0 to 1 while going from first to last tensor.
+           *)
+          let dx = (float_of_int (l + (k + j*d)*d)) /. fd3 in
+          tensors.(i).{j, k, l} <- sin (omega*.(x +. dx));
+        done
+      done
+    done
+  done
+;;
+
+let sum_all (tensors : tensor_array) =
+  let result = ref 0.0 in
+  let n = Array.length tensors in
+  let d = Bigarray.Array3.dim1 tensors.(0) in
+  let () =
+    for i = 0 to n - 1; do
+      for j = 0 to d - 1; do
+        for k = 0 to d - 1; do
+          for l = 0 to d - 1; do
+            let v = tensors.(i).{j, k, l} in
+            result := !result +. v*.v;
+          done
+        done
+      done
+    done
+  in sqrt (!result /. (float_of_int (n*d*d*d)))
+;;
+
+let () =
+  let d = 3 in
+  let n = 1000*1000 in
+  let t0 = Unix.gettimeofday() in
+  let tensors = create_tensors n d in
+  let t1 = Unix.gettimeofday() in
+  let () = init_tensors tensors in
+  let t2 = Unix.gettimeofday() in
+  let result = sum_all tensors in
+  let t3 = Unix.gettimeofday() in
+  begin
+    Printf.printf "Sum is %g\n" result;
+    Printf.printf "Create time %g s\n" (t1 -. t0);
+    Printf.printf "  Init time %g s\n" (t2 -. t1);
+    Printf.printf "   Sum time %g s\n" (t3 -. t2);
+  end
+;;

--- a/multidim-arrays/bigarray_test.ml
+++ b/multidim-arrays/bigarray_test.ml
@@ -1,6 +1,6 @@
 (*
  * Create an array of rank-3 tensors, populate them and compute their norm.
- * In this example, tensors are represented as arrays of arrays of arrays.
+ * In this example, the tensors are all stored inside a single bigarray.
  *)
 
 let pi = 4.0 *. atan 1.0;;

--- a/summation/.gitignore
+++ b/summation/.gitignore
@@ -1,0 +1,2 @@
+array_test
+array_test.s

--- a/summation/Makefile
+++ b/summation/Makefile
@@ -21,3 +21,4 @@ carray_test.s: carray_test.cc
 
 clean:
 	rm -f *.cmi *.cmo *.cmx *.o array_test bigarray_test carray_test
+	rm -f array_test.s


### PR DESCRIPTION
I was interested in your remarks on OCaml vs C performance for numeric code.

Avoiding Bigarray.Genarray gives an order of magnitude performance improvement on my machine (the type annotations and -unsafe seem to have little effect on this example).

Before:

```
time ./bigarray_test
Sum is 0.595922
Create time 3.09944e-06 s
  Init time 1.19804 s
   Sum time 0.446599 s
1.62user 0.03system 0:01.65elapsed 99%CPU (0avgtext+0avgdata 215836maxresident)k
0inputs+0outputs (0major+53400minor)pagefuls 0swaps
```

After:

```
time ./bigarray_test
Sum is 0.595922
Create time 0.214826 s
  Init time 0.730555 s
   Sum time 0.0553079 s
0.94user 0.06system 0:01.01elapsed 99%CPU (0avgtext+0avgdata 304936maxresident)k
0inputs+0outputs (0major+75924minor)pagefuls 0swaps
```
